### PR TITLE
Renaming function

### DIFF
--- a/celcat_to_ics/celcat_to_ics.py
+++ b/celcat_to_ics/celcat_to_ics.py
@@ -143,7 +143,7 @@ def parse_celcat(f, filter=[]):
     return events, calname
 
 
-def run():
+def main():
     args = docopt(doc=__doc__, version=__version__)
     log = Quicklog(
         application_name="celcat_to_ics",


### PR DESCRIPTION
Function was named 'run' instead of 'main'.